### PR TITLE
[CHK-3138] fix: convert transactionId into UUID before send as idempotenceKey

### DIFF
--- a/src/main/kotlin/it/pagopa/helpdeskcommands/client/NpgClient.kt
+++ b/src/main/kotlin/it/pagopa/helpdeskcommands/client/NpgClient.kt
@@ -44,9 +44,9 @@ class NpgClient(
     fun refundPayment(
         apikey: String,
         correlationId: UUID,
-        operationId: String?,
-        idempotenceKey: String,
-        grandTotal: BigDecimal?,
+        operationId: String,
+        idempotenceKey: UUID,
+        grandTotal: BigDecimal,
         description: String?
     ): Mono<RefundResponseDto> {
         return npgWebClient
@@ -54,7 +54,7 @@ class NpgClient(
                 operationId,
                 correlationId,
                 apikey,
-                idempotenceKey,
+                idempotenceKey.toString(),
                 RefundRequestDto()
                     .amount(grandTotal.toString())
                     .currency(PaymentConstants.EUR_CURRENCY)

--- a/src/main/kotlin/it/pagopa/helpdeskcommands/controllers/CommandsController.kt
+++ b/src/main/kotlin/it/pagopa/helpdeskcommands/controllers/CommandsController.kt
@@ -5,6 +5,7 @@ import it.pagopa.generated.helpdeskcommands.model.RefundTransactionRequestDto
 import it.pagopa.generated.helpdeskcommands.model.RefundTransactionResponseDto
 import it.pagopa.helpdeskcommands.services.CommandsService
 import it.pagopa.helpdeskcommands.utils.PaymentMethod
+import it.pagopa.helpdeskcommands.utils.TransactionId
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
@@ -32,7 +33,7 @@ class CommandsController(@Autowired private val commandsService: CommandsService
             commandsService
                 .requestNpgRefund(
                     operationId = it.operationId,
-                    transactionId = it.transactionId,
+                    transactionId = TransactionId(it.transactionId),
                     correlationId = it.correlationId,
                     paymentMethod = PaymentMethod.fromServiceName(it.paymentMethodName),
                     pspId = it.pspId,

--- a/src/main/kotlin/it/pagopa/helpdeskcommands/services/CommandsService.kt
+++ b/src/main/kotlin/it/pagopa/helpdeskcommands/services/CommandsService.kt
@@ -5,6 +5,7 @@ import it.pagopa.helpdeskcommands.client.NpgClient
 import it.pagopa.helpdeskcommands.exceptions.NpgClientException
 import it.pagopa.helpdeskcommands.utils.NpgApiKeyConfiguration
 import it.pagopa.helpdeskcommands.utils.PaymentMethod
+import it.pagopa.helpdeskcommands.utils.TransactionId
 import java.math.BigDecimal
 import java.util.*
 import org.slf4j.Logger
@@ -23,7 +24,7 @@ class CommandsService(
 
     fun requestNpgRefund(
         operationId: String,
-        transactionId: String,
+        transactionId: TransactionId,
         amount: BigDecimal,
         pspId: String,
         correlationId: String,
@@ -46,7 +47,7 @@ class CommandsService(
                     .refundPayment(
                         correlationId = UUID.fromString(correlationId),
                         operationId = operationId,
-                        idempotenceKey = transactionId,
+                        idempotenceKey = transactionId.uuid,
                         grandTotal = amount,
                         apikey = apiKey,
                         description =

--- a/src/main/kotlin/it/pagopa/helpdeskcommands/utils/TransactionId.kt
+++ b/src/main/kotlin/it/pagopa/helpdeskcommands/utils/TransactionId.kt
@@ -1,0 +1,36 @@
+package it.pagopa.helpdeskcommands.utils
+
+import java.util.*
+
+class TransactionId(transactionId: String) {
+
+    val uuid: UUID = fromTrimmedUUIDString(transactionId)
+
+    /**
+     * Get transaction id string value
+     *
+     * @return transaction id as UUID string without dashes
+     */
+    fun value(): String {
+        return uuid.toString().replace("-", "")
+    }
+
+    companion object {
+
+        private fun fromTrimmedUUIDString(trimmedUUIDString: String): UUID {
+            require(trimmedUUIDString.length == 32) {
+                "Invalid transaction id: [${trimmedUUIDString}]. Transaction id must be 32 chars length"
+            }
+            val uuidtring =
+                String.format(
+                    "%s-%s-%s-%s-%s",
+                    trimmedUUIDString.substring(0, 8),
+                    trimmedUUIDString.substring(8, 12),
+                    trimmedUUIDString.substring(12, 16),
+                    trimmedUUIDString.substring(16, 20),
+                    trimmedUUIDString.substring(20, 32)
+                )
+            return UUID.fromString(uuidtring)
+        }
+    }
+}

--- a/src/test/kotlin/it/pagopa/helpdeskcommands/services/CommandsServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/helpdeskcommands/services/CommandsServiceTest.kt
@@ -9,6 +9,7 @@ import it.pagopa.helpdeskcommands.exceptions.NpgClientException
 import it.pagopa.helpdeskcommands.utils.NpgApiKeyConfiguration
 import it.pagopa.helpdeskcommands.utils.NpgPspApiKeysConfig
 import it.pagopa.helpdeskcommands.utils.PaymentMethod
+import it.pagopa.helpdeskcommands.utils.TransactionId
 import java.math.BigDecimal
 import java.util.*
 import java.util.stream.Stream
@@ -34,6 +35,7 @@ class CommandsServiceTest {
 
     final val PSP_ID = "pspId1"
     final val PSP_KEY = "pspId1-paypal-api-key"
+    final val TRANSACTION_ID_STRING = "93cce28d3b7c4cb9975e6d856ecee89f"
 
     private val npgWebClient: PaymentServicesApi =
         WebClientConfig()
@@ -91,7 +93,7 @@ class CommandsServiceTest {
     @Test
     fun requestRefund_200_npg() {
         val operationId = "operationID"
-        val transactionId = UUID.randomUUID().toString()
+        val transactionId = TransactionId(TRANSACTION_ID_STRING)
         val correlationId = UUID.randomUUID().toString()
         val amount = BigDecimal.valueOf(1000)
         // Precondition
@@ -126,7 +128,7 @@ class CommandsServiceTest {
                 eq(PSP_KEY),
                 eq(UUID.fromString(correlationId)),
                 eq(operationId),
-                eq(transactionId),
+                eq(transactionId.uuid),
                 eq(amount),
                 any()
             )
@@ -139,7 +141,7 @@ class CommandsServiceTest {
         expectedException: Class<out Throwable>
     ) {
         val operationId = "operationID"
-        val transactionId = UUID.randomUUID().toString()
+        val transactionId = TransactionId(TRANSACTION_ID_STRING)
         val correlationId = UUID.randomUUID().toString()
         val amount = BigDecimal.valueOf(1000)
         // Precondition
@@ -173,7 +175,7 @@ class CommandsServiceTest {
                 eq(PSP_KEY),
                 eq(UUID.fromString(correlationId)),
                 eq(operationId),
-                eq(transactionId),
+                eq(transactionId.uuid),
                 eq(amount),
                 any()
             )
@@ -186,7 +188,7 @@ class CommandsServiceTest {
         expectedException: Class<out Throwable>
     ) {
         val operationId = "operationID"
-        val transactionId = UUID.randomUUID().toString()
+        val transactionId = TransactionId(TRANSACTION_ID_STRING)
         val correlationId = UUID.randomUUID().toString()
         val amount = BigDecimal.valueOf(1000)
         // Precondition
@@ -210,7 +212,7 @@ class CommandsServiceTest {
                 eq(PSP_KEY),
                 eq(UUID.fromString(correlationId)),
                 eq(operationId),
-                eq(transactionId),
+                eq(transactionId.uuid),
                 eq(amount),
                 any()
             )
@@ -222,7 +224,7 @@ class CommandsServiceTest {
         val refundService =
             CommandsService(npgClient = npgClient, npgApiKeyConfiguration = npgApiKeyConfiguration)
         val operationId = "operationID"
-        val transactionId = UUID.randomUUID().toString()
+        val transactionId = TransactionId(TRANSACTION_ID_STRING)
         val correlationId = UUID.randomUUID().toString()
         val amount = BigDecimal.valueOf(1000)
         // Precondition
@@ -254,7 +256,7 @@ class CommandsServiceTest {
                 eq(PSP_KEY),
                 eq(UUID.fromString(correlationId)),
                 eq(operationId),
-                eq(transactionId),
+                eq(transactionId.uuid),
                 eq(amount),
                 any()
             )
@@ -266,7 +268,7 @@ class CommandsServiceTest {
         val refundService =
             CommandsService(npgClient = npgClient, npgApiKeyConfiguration = npgApiKeyConfiguration)
         val operationId = "operationID"
-        val transactionId = UUID.randomUUID().toString()
+        val transactionId = TransactionId(TRANSACTION_ID_STRING)
         val correlationId = UUID.randomUUID().toString()
         val amount = BigDecimal.valueOf(1000)
         val pspId = "unknown"

--- a/src/test/kotlin/it/pagopa/helpdeskcommands/utils/TransactionIdTest.kt
+++ b/src/test/kotlin/it/pagopa/helpdeskcommands/utils/TransactionIdTest.kt
@@ -1,0 +1,31 @@
+package it.pagopa.helpdeskcommands.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class TransactionIdTest {
+
+    val INVALID_TRANSACTION_ID_STRING = "93cce28d3b7c4cb9975e6d856ecee"
+    val TRANSACTION_ID_STRING = "93cce28d3b7c4cb9975e6d856ecee89f"
+    val TRANSACTION_ID_UUID = "93cce28d-3b7c-4cb9-975e-6d856ecee89f"
+
+    @Test
+    fun shouldReturnUUIDFromValidTransactionId() {
+        val transactionId = TransactionId(TRANSACTION_ID_STRING)
+        assertEquals(TRANSACTION_ID_UUID, transactionId.uuid.toString())
+        assertEquals(TRANSACTION_ID_STRING, transactionId.value())
+    }
+
+    @Test
+    fun shouldThrowExceptionForInvalidTransactionId() {
+        val exception =
+            assertThrows<IllegalArgumentException> { TransactionId(INVALID_TRANSACTION_ID_STRING) }
+
+        assertEquals(
+            "Invalid transaction id: [${INVALID_TRANSACTION_ID_STRING}]. " +
+                "Transaction id must be 32 chars length",
+            exception.message
+        )
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add TransactionId class to manage uuid convertion
- send transactionId.uuid as idempotenceKey into npg client

<!--- Describe your changes in detail -->
The goal of this PR is to fix value passed as idempotenceKey to npgClient. The correct value consist of a transactionId converted into UUID.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.