### PR TITLE
[CHK-3145] Fix log of class object instead of UUID

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,8 +70,8 @@ kotlin { jvmToolchain(21) }
 // dependencyLocking { lockAllConfigurations() }
 
 tasks.create("applySemanticVersionPlugin") {
-    dependsOn("prepareKotlinBuildScriptModel")
-    apply(plugin = "com.dipien.semantic-version")
+  dependsOn("prepareKotlinBuildScriptModel")
+  apply(plugin = "com.dipien.semantic-version")
 }
 
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {

--- a/src/main/kotlin/it/pagopa/helpdeskcommands/services/CommandsService.kt
+++ b/src/main/kotlin/it/pagopa/helpdeskcommands/services/CommandsService.kt
@@ -36,7 +36,7 @@ class CommandsService(
                 logger.info(
                     "Performing NPG refund for transaction with id: [{}] and paymentMethod: [{}]. " +
                         "OperationId: [{}], amount: [{}], pspId: [{}], correlationId: [{}]",
-                    transactionId.uuid,
+                    transactionId.value,
                     paymentMethod,
                     operationId,
                     amount,

--- a/src/main/kotlin/it/pagopa/helpdeskcommands/services/CommandsService.kt
+++ b/src/main/kotlin/it/pagopa/helpdeskcommands/services/CommandsService.kt
@@ -36,7 +36,7 @@ class CommandsService(
                 logger.info(
                     "Performing NPG refund for transaction with id: [{}] and paymentMethod: [{}]. " +
                         "OperationId: [{}], amount: [{}], pspId: [{}], correlationId: [{}]",
-                    transactionId,
+                    transactionId.uuid,
                     paymentMethod,
                     operationId,
                     amount,
@@ -51,7 +51,7 @@ class CommandsService(
                         grandTotal = amount,
                         apikey = apiKey,
                         description =
-                            "Refund request for transactionId $transactionId and operationId $operationId"
+                            "Refund request for transactionId ${transactionId.uuid} and operationId $operationId"
                     )
                     .doOnError(NpgClientException::class.java) { exception: NpgClientException ->
                         logger.error(

--- a/src/main/kotlin/it/pagopa/helpdeskcommands/services/CommandsService.kt
+++ b/src/main/kotlin/it/pagopa/helpdeskcommands/services/CommandsService.kt
@@ -36,7 +36,7 @@ class CommandsService(
                 logger.info(
                     "Performing NPG refund for transaction with id: [{}] and paymentMethod: [{}]. " +
                         "OperationId: [{}], amount: [{}], pspId: [{}], correlationId: [{}]",
-                    transactionId.value,
+                    transactionId.value(),
                     paymentMethod,
                     operationId,
                     amount,
@@ -56,7 +56,7 @@ class CommandsService(
                     .doOnError(NpgClientException::class.java) { exception: NpgClientException ->
                         logger.error(
                             "Exception performing NPG refund for transactionId: [{}] and operationId: [{}]",
-                            transactionId,
+                            transactionId.value(),
                             operationId,
                             exception
                         )


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Bug fix. Logging transactionId now prints the expected UUID and not the class object reference.
<!--- Describe your changes in detail -->

#### Motivation and Context
Logging the transactionId caused a dump of the class object reference.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Manual testing.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.