### PR TITLE
feat: [CHK-3778] upgrade to helm chart 7

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: microservice-chart
   repository: https://pagopa.github.io/aks-microservice-chart-blueprint
-  version: 2.3.1
-digest: sha256:92b42c64847373faa6bf054181be2d7ee61e8b6b6d6a5552bf1479691aa95df3
-generated: "2024-07-31T15:20:04.534353+02:00"
+  version: 7.4.0
+digest: sha256:ba6c74f4d1b23251f9256f33bbc5ac6eaaf586569c0b43e37ad413f6d36ceabe
+generated: "2025-03-06T11:49:54.567811+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.14.2
 appVersion: 0.14.2
 dependencies:
   - name: microservice-chart
-    version: 2.3.1
+    version: 7.4.0
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,6 +2,20 @@ microservice-chart:
   namespace: "ecommerce"
   nameOverride: ""
   fullnameOverride: "pagopa-ecommerce-helpdesk-commands-service"
+  canaryDelivery:
+    create: false
+    ingress:
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopadcommonacr.azurecr.io/pagopaecommercehelpdeskcommandsservice
+      tag: "latest"
+    envConfig: { }
+    envSecret: { }
   image:
     repository: pagopadcommonacr.azurecr.io/pagopaecommercehelpdeskcommandsservice
     tag: "0.14.2"
@@ -34,8 +48,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -113,7 +127,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
-  canaryDelivery:
-    deployment:
-      image:
-        tag: ""
+  azure:
+    workloadIdentityClientId: 1be61b58-24e2-49c8-b401-89ebd004bf2e

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -34,8 +34,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -113,7 +113,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
-  canaryDelivery:
-    deployment:
-      image:
-        tag: ""
+  azure:
+    workloadIdentityClientId: "d5614882-90dd-47a1-aad1-cdf295201469"

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,6 +2,20 @@ microservice-chart:
   namespace: "ecommerce"
   nameOverride: ""
   fullnameOverride: "pagopa-ecommerce-helpdesk-commands-service"
+  canaryDelivery:
+    create: false
+    ingress:
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopapcommonacr.azurecr.io/pagopaecommercehelpdeskcommandsservice
+      tag: "latest"
+    envConfig: { }
+    envSecret: { }
   image:
     repository: pagopapcommonacr.azurecr.io/pagopaecommercehelpdeskcommandsservice
     tag: "0.14.2"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -14,9 +14,7 @@ microservice-chart:
     image:
       repository: pagopaucommonacr.azurecr.io/pagopaecommercehelpdeskcommandsservice
       tag: "latest"
-    envConfig:
-      ECS_SERVICE_NAME: "pagopa-ecommerce-helpdesk-commands-service-blue"
-      OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-ecommerce-helpdesk-commands-service-blue,deployment.environment=uat"
+    envConfig: { }
     envSecret: { }
   image:
     repository: pagopaucommonacr.azurecr.io/pagopaecommercehelpdeskcommandsservice

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -48,8 +48,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,6 +2,22 @@ microservice-chart:
   namespace: "ecommerce"
   nameOverride: ""
   fullnameOverride: "pagopa-ecommerce-helpdesk-commands-service"
+  canaryDelivery:
+    create: false
+    ingress:
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopaucommonacr.azurecr.io/pagopaecommercehelpdeskcommandsservice
+      tag: "latest"
+    envConfig:
+      ECS_SERVICE_NAME: "pagopa-ecommerce-helpdesk-commands-service-blue"
+      OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-ecommerce-helpdesk-commands-service-blue,deployment.environment=uat"
+    envSecret: { }
   image:
     repository: pagopaucommonacr.azurecr.io/pagopaecommercehelpdeskcommandsservice
     tag: "0.14.2"
@@ -113,7 +129,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
-  canaryDelivery:
-    deployment:
-      image:
-        tag: ""
+  azure:
+    workloadIdentityClientId: 449c5b65-f368-487a-881a-b03676420c53


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Upgrade to helm chart 7 from helm chart 2.

#### List of Changes
Upgrade to helm chart 7 performing the following modifications:
- chat version update from 2.3.1 to 7.4.0
- canaryDelivery parameter update to the new template (adding canary section)
- add workload identity refs for each environment specifying the azure workload identity client id and service account name for each env

#### Motivation and Context
These modifications are needed to enable the eCommerce helpdesk commands service to use workload identities instead of the deprecated pod identity.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

No tests yet

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.