### PR TITLE
chore: [CHK-4827] replace ReactiveMongoRepository save with insert for event-store repository

### DIFF
--- a/api-tests/env/helpdeskcommands_dev.env.json
+++ b/api-tests/env/helpdeskcommands_dev.env.json
@@ -16,7 +16,7 @@
 		},
 		{
 			"key": "TRANSACTION_ID_NOT_EXISTS",
-			"value": "5f521592f3d84ffa8d8f68651da91123",
+			"value": "5f521592f3d84ffa8d8f68651da90000",
 			"type": "default",
 			"enabled": true
 		},

--- a/api-tests/env/helpdeskcommands_uat.env.json
+++ b/api-tests/env/helpdeskcommands_uat.env.json
@@ -16,7 +16,7 @@
 		},
 		{
 			"key": "TRANSACTION_ID_NOT_EXISTS",
-			"value": "ecf06892c9e04ae39626dfdfda631123",
+			"value": "ecf06892c9e04ae39626dfdfda630000",
 			"type": "default",
 			"enabled": true
 		},

--- a/api-tests/v1/helpdeskcommands.api.tests.dev.json
+++ b/api-tests/v1/helpdeskcommands.api.tests.dev.json
@@ -74,13 +74,13 @@
 			"response": []
 		},
 		{
-			"name": "eCommerce helpDesk-Commands Refund Operation - Operation Already Refunded",
+			"name": "eCommerce helpDesk-Commands Refund Operation - Operation with invalid amount",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test(\"eCommerce helpDesk-Commands Refund Operation but target resource has already been refunded\", function () {",
+							"pm.test(\"eCommerce helpDesk-Commands Refund Operation but requested amount is invalid\", function () {",
 							"    pm.response.to.have.status(500);",
 							"    const response = pm.response.json();",
 							"    pm.expect(response.title).to.be.eq(\"Npg Invocation exception - Bad request\");",
@@ -117,7 +117,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"transactionId\": \"{{TRANSACTION_ID_NOT_EXISTS}}\",\r\n    \"paymentMethodName\": \"{{PAYMENT_METHOD_NAME}}\",\r\n    \"correlationId\": \"{{CORRELATION_ID}}\",\r\n    \"operationId\": \"{{OPERATION_ID}}\",\r\n    \"pspId\": \"{{PSP_ID}}\",\r\n    \"amount\": {{AMOUNT}}\r\n}",
+					"raw": "{\r\n    \"transactionId\": \"{{TRANSACTION_ID_NOT_EXISTS}}\",\r\n    \"paymentMethodName\": \"{{PAYMENT_METHOD_NAME}}\",\r\n    \"correlationId\": \"{{CORRELATION_ID}}\",\r\n    \"operationId\": \"{{OPERATION_ID}}\",\r\n    \"pspId\": \"{{PSP_ID}}\",\r\n    \"amount\": 121000\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -251,7 +251,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"idTransaction\": \"{{TRANSACTION_ID}}\",\r\n    \"idPSPTransaction\": \"{{PSP_TRANSACTION_ID}}\",\r\n    \"touchpoint\": \"{{TOUCHPOINT}}\",\r\n    \"paymentTypeCode\": \"{{NOT_VALID_REDIRECT_PAYMENT_METHOD_NAME}}\",\r\n    \"pspId\": \"{{PSP_ID}}\"\r\n}",
+					"raw": "{\r\n    \"idTransaction\": \"{{TRANSACTION_ID}}\",\r\n    \"idPSPTransaction\": \"{{PSP_TRANSACTION_ID}}\",\r\n    \"touchpoint\": \"{{TOUCHPOINT}}\",\r\n    \"paymentTypeCode\": \"{{NOT_VALID_REDIRECT_PAYMENT_METHOD_NAME}}\",\r\n    \"pspId\": \"{{REDIRECT_PSP_ID}}\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/api-tests/v1/helpdeskcommands.api.tests.uat.json
+++ b/api-tests/v1/helpdeskcommands.api.tests.uat.json
@@ -74,13 +74,13 @@
 			"response": []
 		},
 		{
-			"name": "eCommerce helpDesk-Commands Refund Operation - Operation Already Refunded",
+			"name": "eCommerce helpDesk-Commands Refund Operation - Operation with invalid amount",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test(\"eCommerce helpDesk-Commands Refund Operation but target resource has already been refunded\", function () {",
+							"pm.test(\"eCommerce helpDesk-Commands Refund Operation but requested amount is invalid\", function () {",
 							"    pm.response.to.have.status(500);",
 							"    const response = pm.response.json();",
 							"    pm.expect(response.title).to.be.eq(\"Npg Invocation exception - Bad request\");",
@@ -117,7 +117,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"transactionId\": \"{{TRANSACTION_ID_NOT_EXISTS}}\",\r\n    \"paymentMethodName\": \"{{PAYMENT_METHOD_NAME}}\",\r\n    \"correlationId\": \"{{CORRELATION_ID}}\",\r\n    \"operationId\": \"{{OPERATION_ID}}\",\r\n    \"pspId\": \"{{PSP_ID}}\",\r\n    \"amount\": {{AMOUNT}}\r\n}",
+					"raw": "{\r\n    \"transactionId\": \"{{TRANSACTION_ID_NOT_EXISTS}}\",\r\n    \"paymentMethodName\": \"{{PAYMENT_METHOD_NAME}}\",\r\n    \"correlationId\": \"{{CORRELATION_ID}}\",\r\n    \"operationId\": \"{{OPERATION_ID}}\",\r\n    \"pspId\": \"{{PSP_ID}}\",\r\n    \"amount\": 121000\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/src/main/kotlin/it/pagopa/helpdeskcommands/services/TransactionEventService.kt
+++ b/src/main/kotlin/it/pagopa/helpdeskcommands/services/TransactionEventService.kt
@@ -248,7 +248,7 @@ class TransactionEventService(
         transactionsViewRepository: TransactionsViewRepository
     ): Mono<BaseTransaction?> {
         return transactionsEventStoreRepository
-            .save(refundRequestedEvent as TransactionEvent<BaseTransactionRefundedData>)
+            .insert(refundRequestedEvent as TransactionEvent<BaseTransactionRefundedData>)
             .then(
                 transactionsViewRepository
                     .findByTransactionId(transaction.transactionId.value())
@@ -324,7 +324,7 @@ class TransactionEventService(
 
                         // Save the new event
                         userReceiptEventStoreRepository
-                            .save(newEvent)
+                            .insert(newEvent)
                             .then(
                                 transactionsViewRepository
                                     .findByTransactionId(transaction.transactionId.value())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 
 #Ecommerce mongo database configurations
-mongodb.uri=mongodb://\${MONGO_USERNAME}:\${MONGO_PASSWORD}@\${MONGO_HOST}:\${MONGO_PORT}/?ssl=\${MONGO_SSL_ENABLED}&readPreference=secondary&minPoolSize=\${MONGO_MIN_POOL_SIZE}&maxPoolSize=\${MONGO_MAX_POOL_SIZE}&maxIdleTimeMS=\${MONGO_MAX_IDLE_TIMEOUT_MS}&connectTimeoutMS=\${MONGO_CONNECTION_TIMEOUT_MS}&socketTimeoutMS=\${MONGO_SOCKET_TIMEOUT_MS}&serverSelectionTimeoutMS=\${MONGO_SERVER_SELECTION_TIMEOUT_MS}&waitQueueTimeoutMS=\${MONGO_WAITING_QUEUE_MS}&heartbeatFrequencyMS=\${MONGO_HEARTBEAT_FREQUENCY_MS}
+mongodb.uri=mongodb://\${MONGO_USERNAME}:\${MONGO_PASSWORD}@\${MONGO_HOST}:\${MONGO_PORT}/?ssl=\${MONGO_SSL_ENABLED}&readPreference=secondary&minPoolSize=\${MONGO_MIN_POOL_SIZE}&maxPoolSize=\${MONGO_MAX_POOL_SIZE}&maxIdleTimeMS=\${MONGO_MAX_IDLE_TIMEOUT_MS}&connectTimeoutMS=\${MONGO_CONNECTION_TIMEOUT_MS}&socketTimeoutMS=\${MONGO_SOCKET_TIMEOUT_MS}&serverSelectionTimeoutMS=\${MONGO_SERVER_SELECTION_TIMEOUT_MS}&waitQueueTimeoutMS=\${MONGO_WAITING_QUEUE_MS}&heartbeatFrequencyMS=\${MONGO_HEARTBEAT_FREQUENCY_MS}&retryWrites=false
 mongodb.ecommerce.database=\${ECOMMERCE_DATABASE_NAME}
 mongodb.ecommerce_history.database=\${ECOMMERCE_HISTORY_DATABASE_NAME}
 

--- a/src/test/kotlin/it/pagopa/helpdeskcommands/services/TransactionEventServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/helpdeskcommands/services/TransactionEventServiceTest.kt
@@ -921,7 +921,8 @@ class TransactionEventServiceTest {
             .verifyComplete()
 
         // Verify repository calls
-        verify(transactionsRefundedEventStoreRepository).insert(any<TransactionEvent<BaseTransactionRefundedData>>())
+        verify(transactionsRefundedEventStoreRepository)
+            .insert(any<TransactionEvent<BaseTransactionRefundedData>>())
         verify(transactionsViewRepository).findByTransactionId(transactionIdString)
         verify(transactionsViewRepository).save(any())
     }

--- a/src/test/kotlin/it/pagopa/helpdeskcommands/services/TransactionEventServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/helpdeskcommands/services/TransactionEventServiceTest.kt
@@ -394,7 +394,7 @@ class TransactionEventServiceTest {
                 Mono.just(invocation.getArgument(0) as TransactionUserReceiptRequestedEvent)
             }
             .`when`(userReceiptEventStoreRepository)
-            .save(any())
+            .insert(any<TransactionUserReceiptRequestedEvent>())
 
         val mockTx = Mockito.mock(Transaction::class.java)
         doReturn(Mono.just(mockTx))
@@ -418,7 +418,7 @@ class TransactionEventServiceTest {
             }
             .verifyComplete()
 
-        verify(userReceiptEventStoreRepository).save(capture(userReceiptEventCaptor))
+        verify(userReceiptEventStoreRepository).insert(capture(userReceiptEventCaptor))
         val savedEvent = userReceiptEventCaptor.value
         assertEquals(transactionIdString, savedEvent.transactionId)
     }
@@ -453,7 +453,7 @@ class TransactionEventServiceTest {
                 Mono.just(invocation.getArgument(0) as TransactionUserReceiptRequestedEvent)
             }
             .`when`(userReceiptEventStoreRepository)
-            .save(any())
+            .insert(any<TransactionUserReceiptRequestedEvent>())
 
         val mockTx = Mockito.mock(Transaction::class.java)
         doReturn(Mono.just(mockTx))
@@ -477,7 +477,7 @@ class TransactionEventServiceTest {
             }
             .verifyComplete()
 
-        verify(userReceiptEventStoreRepository).save(capture(userReceiptEventCaptor))
+        verify(userReceiptEventStoreRepository).insert(capture(userReceiptEventCaptor))
         val savedEvent = userReceiptEventCaptor.value
         assertEquals(transactionIdString, savedEvent.transactionId)
     }
@@ -512,7 +512,7 @@ class TransactionEventServiceTest {
                 Mono.just(invocation.getArgument(0) as TransactionUserReceiptRequestedEvent)
             }
             .`when`(userReceiptEventStoreRepository)
-            .save(any())
+            .insert(any<TransactionUserReceiptRequestedEvent>())
 
         val mockTx = Mockito.mock(Transaction::class.java)
         doReturn(Mono.just(mockTx))
@@ -536,7 +536,7 @@ class TransactionEventServiceTest {
             }
             .verifyComplete()
 
-        verify(userReceiptEventStoreRepository).save(capture(userReceiptEventCaptor))
+        verify(userReceiptEventStoreRepository).insert(capture(userReceiptEventCaptor))
         val savedEvent = userReceiptEventCaptor.value
         assertEquals(transactionIdString, savedEvent.transactionId)
     }
@@ -571,7 +571,7 @@ class TransactionEventServiceTest {
                 Mono.just(invocation.getArgument(0) as TransactionUserReceiptRequestedEvent)
             }
             .`when`(userReceiptEventStoreRepository)
-            .save(any())
+            .insert(any<TransactionUserReceiptRequestedEvent>())
 
         val mockTx = Mockito.mock(Transaction::class.java)
         doReturn(Mono.just(mockTx))
@@ -595,7 +595,7 @@ class TransactionEventServiceTest {
             }
             .verifyComplete()
 
-        verify(userReceiptEventStoreRepository).save(capture(userReceiptEventCaptor))
+        verify(userReceiptEventStoreRepository).insert(capture(userReceiptEventCaptor))
         val savedEvent = userReceiptEventCaptor.value
         assertEquals(transactionIdString, savedEvent.transactionId)
     }
@@ -626,7 +626,7 @@ class TransactionEventServiceTest {
                 Mono.error<TransactionUserReceiptRequestedEvent>(RuntimeException("Database error"))
             )
             .`when`(userReceiptEventStoreRepository)
-            .save(any())
+            .insert(any<TransactionUserReceiptRequestedEvent>())
 
         // When
         val result = transactionEventServiceSpy.resendUserReceiptNotification(transactionIdString)
@@ -634,7 +634,7 @@ class TransactionEventServiceTest {
         // Then
         StepVerifier.create(result).expectError(RuntimeException::class.java).verify()
 
-        verify(userReceiptEventStoreRepository).save(any())
+        verify(userReceiptEventStoreRepository).insert(any<TransactionUserReceiptRequestedEvent>())
     }
 
     @Test
@@ -669,7 +669,7 @@ class TransactionEventServiceTest {
                 Mono.just(invocation.getArgument(0) as TransactionUserReceiptRequestedEvent)
             }
             .`when`(userReceiptEventStoreRepository)
-            .save(any())
+            .insert(any<TransactionUserReceiptRequestedEvent>())
 
         val mockTx = Mockito.mock(Transaction::class.java)
         doReturn(Mono.just(mockTx))
@@ -694,7 +694,7 @@ class TransactionEventServiceTest {
             }
             .verifyComplete()
 
-        verify(userReceiptEventStoreRepository).save(capture(userReceiptEventCaptor))
+        verify(userReceiptEventStoreRepository).insert(capture(userReceiptEventCaptor))
         val savedEvent = userReceiptEventCaptor.value
         assertEquals(transactionIdString, savedEvent.transactionId)
     }
@@ -884,7 +884,7 @@ class TransactionEventServiceTest {
         @Suppress("UNCHECKED_CAST")
         doReturn(Mono.just(transactionEvent as TransactionEvent<BaseTransactionRefundedData>))
             .`when`(transactionsRefundedEventStoreRepository)
-            .save(any())
+            .insert(any<TransactionEvent<BaseTransactionRefundedData>>())
 
         @Suppress("UNCHECKED_CAST")
         doReturn(Mono.empty<TransactionEvent<BaseTransactionRefundedData>>())
@@ -921,7 +921,7 @@ class TransactionEventServiceTest {
             .verifyComplete()
 
         // Verify repository calls
-        verify(transactionsRefundedEventStoreRepository).save(any())
+        verify(transactionsRefundedEventStoreRepository).insert(any<TransactionEvent<BaseTransactionRefundedData>>())
         verify(transactionsViewRepository).findByTransactionId(transactionIdString)
         verify(transactionsViewRepository).save(any())
     }
@@ -953,7 +953,7 @@ class TransactionEventServiceTest {
 
         doReturn(Mono.just(mockTransaction))
             .`when`(transactionsRefundedEventStoreRepository)
-            .save(any<TransactionEvent<BaseTransactionRefundedData>>())
+            .insert(any<TransactionEvent<BaseTransactionRefundedData>>())
 
         doReturn(Mono.empty<TransactionActivatedEvent>())
             .`when`(transactionsRefundedEventStoreHistoryRepository)
@@ -978,7 +978,7 @@ class TransactionEventServiceTest {
             .verifyComplete()
 
         verify(transactionsRefundedEventStoreRepository)
-            .save(any<TransactionEvent<BaseTransactionRefundedData>>())
+            .insert(any<TransactionEvent<BaseTransactionRefundedData>>())
         verify(transactionsViewRepository).findByTransactionId(transactionIdString)
         verify(transactionsViewRepository).save(any())
     }
@@ -1101,7 +1101,7 @@ class TransactionEventServiceTest {
 
         doReturn(Mono.just(existingReceiptEvent))
             .`when`(userReceiptEventStoreRepository)
-            .save(any())
+            .insert(any<TransactionUserReceiptRequestedEvent>())
 
         val mockTx = Mockito.mock(Transaction::class.java)
         doReturn(Mono.just(mockTx))
@@ -1130,7 +1130,7 @@ class TransactionEventServiceTest {
         // Verify repository calls
         verify(userReceiptEventStoreRepository)
             .findByTransactionIdOrderByCreationDateAsc(transactionIdString)
-        verify(userReceiptEventStoreRepository).save(any())
+        verify(userReceiptEventStoreRepository).insert(any<TransactionUserReceiptRequestedEvent>())
     }
 
     @Test


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Replaced TransactionsEventStoreRepository saves with inserts
- Added retryWrites=false to MongoDB URI
- Refactored API tests

#### Motivation and Context

The goal is to replace all event store _upsert_ queries to _insert_ queries, by replacing the `ReactiveMongoRepository` _save_ method with the _insert_ method.

#### How Has This Been Tested?

- Unit test
- API test

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.