### PR TITLE
[PIDM-2139] fix: run container process as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN --mount=type=secret,id=GITHUB_TOKEN \
                 --strict-image-heap -H:+AddAllCharsets"
 
 FROM debian:stable-20240701-slim@sha256:f8bbfa052db81e5b8ac12e4a1d8310a85d1509d4d0d5579148059c0e8b717d4e AS runtime
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+USER appuser:appgroup
 WORKDIR /app
 EXPOSE 8080
 COPY --from=builder /workspace/app/build/native/nativeCompile/pagopa-helpdesk-commands-service .

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN --mount=type=secret,id=GITHUB_TOKEN \
 
 FROM debian:stable-20240701-slim@sha256:f8bbfa052db81e5b8ac12e4a1d8310a85d1509d4d0d5579148059c0e8b717d4e AS runtime
 RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
-USER appuser:appgroup
 WORKDIR /app
 EXPOSE 8080
 COPY --from=builder /workspace/app/build/native/nativeCompile/pagopa-helpdesk-commands-service .
+USER appuser:appgroup
 ENTRYPOINT ["./pagopa-helpdesk-commands-service"]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added a dedicated non-root system user and group (appuser:appgroup) in the runtime stage of the Dockerfile
- Added USER appuser:appgroup instruction immediately after user creation, before WORKDIR and COPY

#### Motivation and Context

Running container processes as root exposes the system to container escape risk if the process is compromised. This change introduces a dedicated non-root user (appuser:appgroup) to enforce the principle of least privilege, fixing the DS-0002 (HIGH) vulnerability detected by Trivy.

#### How Has This Been Tested?

Tested using Trivy v0.71.2 scanning the Dockerfile directly with trivy config:
```
trivy config Dockerfile.before  # Failures: 2 (HIGH: 1, LOW: 1)
trivy config Dockerfile.after   # Failures: 1 (LOW: 1)
```
| | Before | After |
|---|---|---|
| **DS-0002 (HIGH)** root user | ✗ present | ✓ resolved |
| **DS-0026 (LOW)** no HEALTHCHECK | ✗ present | ✗ present (out of scope) |
| **Total failures** | 2 | 1 |

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.